### PR TITLE
Group by top journals

### DIFF
--- a/core/fields.py
+++ b/core/fields.py
@@ -206,11 +206,13 @@ class DateTimeField(DateField):
 class OpenAlexIDField(Field):
     def build_query(self):
         if self.value == "null" and self.param != "repository":
+            # TODO: change above to `...self.param not in ["repository", "journal"]`?
             field_name = self.es_field()
             field_name = field_name.replace("__", ".")
             q = ~Q("exists", field=field_name)
             return q
         elif self.value == "!null" and self.param != "repository":
+            # TODO: change above to `...self.param not in ["repository", "journal"]`?
             field_name = self.es_field()
             field_name = field_name.replace("__", ".")
             q = Q("exists", field=field_name)
@@ -221,6 +223,7 @@ class OpenAlexIDField(Field):
             kwargs = {self.es_field(): query}
             if self.param == "repository":
                 q = ~Q("term", locations__source__id=query)
+            # TODO: add a similar one for "journal," but use `primary_location__source__id`?
             else:
                 q = ~Q("term", **kwargs)
             return q
@@ -231,6 +234,7 @@ class OpenAlexIDField(Field):
             openalex_ids = self.get_ids(self.value, "related_works")
             q = Q("terms", id=openalex_ids)
         elif self.param == "repository":
+            # TODO: add similar logic for "journal" (with primary_location.source.type)?
             if self.value == "null":
                 q = ~Q("exists", field=self.custom_es_field) & Q(
                     "term", **{"locations.source.type": "repository"}

--- a/core/group_by.py
+++ b/core/group_by.py
@@ -27,7 +27,8 @@ def group_by_records(field, s, sort_params, known, per_page, q):
         or field.param == "locations.source.host_institution_lineage"
     ):
         s = s.filter("term", **{"locations.source.type": "repository"})
-    # TODO: add a similar filter for "journal" (with `primary_location.source.type`)?
+    if field.param == "journal":
+        s = s.filter("term", **{"primary_location.source.type": "journal"})
 
     if sort_params:
         for key, order in sort_params.items():
@@ -186,7 +187,7 @@ def get_group_by_results(group_by, response):
         group_by.endswith(".id")
         or group_by.endswith("host_organization")
         or group_by.endswith("repository")
-        # TODO: do we need something similar here for "journal"?
+        or group_by.endswith("journal")
         or group_by.endswith("host_organization_lineage")
         or group_by.endswith("host_institution_lineage")
         or group_by.endswith("publisher_lineage")
@@ -511,7 +512,7 @@ def filter_group_by(field, group_by, q, s):
         or "institution" in group_by
         or group_by == "repository"
         or group_by == "locations.source.host_institution_lineage"
-        # TODO: do we need something similar here for "journal"?
+        or group_by == "journal"
         or group_by == "locations.source.host_organization"
         or group_by == "locations.source.publisher_lineage"
         or group_by == "lineage"

--- a/core/group_by.py
+++ b/core/group_by.py
@@ -24,6 +24,7 @@ def group_by_records(field, s, sort_params, known, per_page, q):
 
     if field.param == "repository":
         s = s.filter("term", **{"locations.source.type": "repository"})
+    # TODO: add a similar filter for "journal" (with `primary_location.source.type`)?
 
     if sort_params:
         for key, order in sort_params.items():
@@ -182,6 +183,7 @@ def get_group_by_results(group_by, response):
         group_by.endswith(".id")
         or group_by.endswith("host_organization")
         or group_by.endswith("repository")
+        # TODO: do we need something similar here for "journal"?
         or group_by.endswith("host_organization_lineage")
     ):
         keys = [b.key for b in buckets]
@@ -479,6 +481,7 @@ def filter_group_by(field, group_by, q, s):
         "author" in group_by
         or "institution" in group_by
         or group_by == "repository"
+        # TODO: do we need something similar here for "journal"?
         or group_by == "locations.source.host_organization"
         or group_by == "lineage"
     ):

--- a/tests/functional/test_works_convenience_filters.py
+++ b/tests/functional/test_works_convenience_filters.py
@@ -271,6 +271,73 @@ class TestWorksRepositoryFilter:
         assert json_data["filters"][0]["values"][0]["display_name"] == None
 
 
+class TestWorksJournalFilter:
+    def test_works_journal_short(self, client):
+        res = client.get("/works?filter=journal:S137773608")
+        json_data = res.get_json()
+        assert json_data["meta"]["count"] > 0
+        for result in json_data["results"]:
+            found = False
+            for result in json_data["results"]:
+                found = False
+                for item in result["locations"]:
+                    if (
+                        "source" in item
+                        and item["source"]
+                        and item["source"].get("id")
+                        == "https://openalex.org/S137773608"
+                    ):
+                        found = True
+                assert found is True
+
+    def test_works_journal_long(self, client):
+        res = client.get("/works?filter=journal:https://openalex.org/S137773608")
+        json_data = res.get_json()
+        assert json_data["meta"]["count"] > 0
+        for result in json_data["results"]:
+            found = False
+            for item in result["locations"]:
+                if (
+                    "source" in item
+                    and item["source"]
+                    and item["source"].get("id") == "https://openalex.org/S137773608"
+                ):
+                    found = True
+            assert found is True
+
+    def test_works_journal_not(self, client):
+        res = client.get("/works?filter=repository:!https://openalex.org/S137773608")
+        json_data = res.get_json()
+        assert json_data["meta"]["count"] > 0
+        for result in json_data["results"]:
+            found = False
+            if "locations" not in result:
+                continue
+            for item in result["locations"]:
+                if (
+                    item.get("source")
+                    and item.get("source").get("id")
+                    and item["source"]["id"] == "https://openalex.org/S137773608"
+                ):
+                    found = True
+            assert found is False
+
+    def test_works_journal_null(self, client):
+        res = client.get("/works?filter=journal:null")
+        json_data = res.get_json()
+        assert json_data["meta"]["count"] == 0
+
+    def test_works_journal_not_null(self, client):
+        res = client.get("/works?filter=journal:!null")
+        json_data = res.get_json()
+        assert json_data["meta"]["count"] > 0
+
+    def test_works_journal_group_by(self, client):
+        res = client.get("/works?group_by=journal")
+        json_data = res.get_json()
+        assert len(json_data["group_by"]) > 0
+
+
 class TestWorksAuthorsCount:
     def test_works_authors_count_exact(self, client):
         res = client.get("/works?filter=authors_count:1")

--- a/works/fields.py
+++ b/works/fields.py
@@ -89,6 +89,7 @@ fields = [
     OpenAlexIDField(param="openalex", custom_es_field="ids.openalex.lower"),
     OpenAlexIDField(param="openalex_id", alias="ids.openalex"),
     OpenAlexIDField(param="repository", custom_es_field="locations.source.id"),
+    # TODO: make another entry for "journal" with custom_es_field="primary_location.source.id"?
     OpenAlexIDField(param="referenced_works"),
     OpenAlexIDField(param="related_to"),
     PhraseField(param="host_venue.publisher"),

--- a/works/fields.py
+++ b/works/fields.py
@@ -97,7 +97,7 @@ fields = [
     OpenAlexIDField(param="openalex", custom_es_field="ids.openalex.lower"),
     OpenAlexIDField(param="openalex_id", alias="ids.openalex"),
     OpenAlexIDField(param="repository", custom_es_field="locations.source.id"),
-    # TODO: make another entry for "journal" with custom_es_field="primary_location.source.id"?
+    OpenAlexIDField(param="journal", custom_es_field="primary_location.source.id"),
     OpenAlexIDField(param="referenced_works"),
     OpenAlexIDField(param="related_to"),
     PhraseField(param="host_venue.publisher"),


### PR DESCRIPTION
from JPriem:
"Requires a "journals" convenience filter, one parallel with the "repositories" filter...it just allows grouping by source where the source is of type "journal."

i think we can do a little hack for this one: there should only be one location with source.type=journal in any work.locations list. moreover, when such a location exists, it's automatically promoted to primary_location.

so behind the scenes, we can just group by primary_location.source after filtering for work.primary_location.source.type=journal.

this should solve the problem where we can't properly group by list item properties (a side-effect of making elastic faster) and so the high-frequency items in lists can creep in to group_bys."