### PR TITLE
add in groupby values with zero counts

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -18,6 +18,7 @@ PUBLISHERS_INDEX = "publishers-v4"
 SOURCES_INDEX = "sources-v2"
 VENUES_INDEX = "venues-v8"
 WORKS_INDEX = "works-v18-*,-*invalid-data"
+GROUPBY_VALUES_INDEX = "groupby_values"
 
 DO_NOT_GROUP_BY = [
     "cited_by",


### PR DESCRIPTION
There is a new elasticsearch index "groupby_values" which keeps track of possible groupby buckets for all simple groupby queries, if there are fewer than 200 possible values. This pull requests gets these values, and adds them to the groupby response as zero values if they are not present after the groupby result is constructed.