### PR TITLE
New author index transition

### DIFF
--- a/authors/views.py
+++ b/authors/views.py
@@ -9,9 +9,28 @@ from core.shared_view import shared_view
 from core.utils import (get_flattened_fields, get_valid_fields, is_cached,
                         process_only_fields)
 from extensions import cache
-from settings import AUTHORS_INDEX
+from settings import AUTHORS_INDEX, AUTHORS_INDEX_OLD
 
 blueprint = Blueprint("authors", __name__)
+
+
+def is_query_for_old_authors():
+    # backwards compatability check. returns True if all of the author IDs requested are old authors
+    from core.utils import map_filter_params, get_index_name_by_id
+    filter_params = map_filter_params(request.args.get("filter"))
+    if filter_params:
+        fields_to_check = ['openalex', 'openalex_id']
+        index_list = []
+        for filter in filter_params:
+            for key, value in filter.items():
+                if key in fields_to_check:
+                    openalex_ids = value.split('|')
+                    for openalex_id in openalex_ids:
+                        index_list.append(get_index_name_by_id(openalex_id))
+        if index_list and all([index_name == AUTHORS_INDEX_OLD for index_name in index_list]):
+            return True
+    return False
+
 
 
 @blueprint.route("/authors")
@@ -21,6 +40,8 @@ blueprint = Blueprint("authors", __name__)
 )
 def authors():
     index_name = AUTHORS_INDEX
+    if is_query_for_old_authors() is True:
+        index_name = AUTHORS_INDEX_OLD
     default_sort = ["-works_count", "id"]
     only_fields = process_only_fields(request, AuthorsSchema)
     result = shared_view(request, fields_dict, index_name, default_sort)

--- a/core/utils.py
+++ b/core/utils.py
@@ -8,7 +8,7 @@ import settings
 from core.exceptions import APIQueryParamsError, HighAuthorCountError
 from settings import (AUTHORS_INDEX, CONCEPTS_INDEX, GROUPBY_VALUES_INDEX,
                       INSTITUTIONS_INDEX, PUBLISHERS_INDEX, SOURCES_INDEX,
-                      VENUES_INDEX, WORKS_INDEX)
+                      VENUES_INDEX, WORKS_INDEX, AUTHORS_INDEX_OLD)
 
 
 def get_valid_fields(fields_dict):
@@ -198,6 +198,12 @@ def get_index_name_by_id(openalex_id):
     index_name = None
     if clean_id.startswith("A"):
         index_name = AUTHORS_INDEX
+        try:
+            id_int = int(clean_id[1:])
+            if id_int < 5000000000:
+                index_name = AUTHORS_INDEX_OLD
+        except (TypeError, ValueError):
+            pass
     elif clean_id.startswith("C"):
         index_name = CONCEPTS_INDEX
     elif clean_id.startswith("I"):

--- a/ids/views.py
+++ b/ids/views.py
@@ -18,7 +18,7 @@ from institutions.schemas import InstitutionsSchema
 from publishers.schemas import PublishersSchema
 from settings import (AUTHORS_INDEX, CONCEPTS_INDEX, FUNDERS_INDEX,
                       INSTITUTIONS_INDEX, PUBLISHERS_INDEX, SOURCES_INDEX,
-                      WORKS_INDEX)
+                      WORKS_INDEX, AUTHORS_INDEX_OLD)
 from sources.schemas import SourcesSchema
 from works.schemas import WorksSchema
 
@@ -147,6 +147,8 @@ def authors_id_get(id):
         if clean_id != id:
             return redirect(url_for("ids.authors_id_get", id=clean_id, **request.args))
         author_id = int(clean_id[1:])
+        if author_id < 5000000000:
+            s = Search(index=AUTHORS_INDEX_OLD)
         full_author_id = f"https://openalex.org/A{author_id}"
         query = Q("term", ids__openalex=full_author_id)
         s = s.filter(query)

--- a/settings.py
+++ b/settings.py
@@ -10,7 +10,8 @@ JSON_SORT_KEYS = False
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # indexes
-AUTHORS_INDEX = "authors-v10"
+AUTHORS_INDEX = "authors-v11"
+AUTHORS_INDEX_OLD = "authors-v10"
 CONCEPTS_INDEX = "concepts-v8"
 FUNDERS_INDEX = "funders-v3"
 INSTITUTIONS_INDEX = "institutions-v5"


### PR DESCRIPTION
This is the switch from authors-v10 to authors-v11, which is the elasticsearch authors index for the new author disambiguation system (V3). It implements a temporary fallback to the old index for as long as that is active. This fallback works if an old ID is requested, or if a filter request is made and every ID requested is in the old index. (the id cutoff for old/new is 5000000000)