### PR TITLE
Add vector search documentation for /find/works endpoint

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -97,6 +97,7 @@
   * [Sample entity lists](how-to-use-the-api/get-lists-of-entities/sample-entity-lists.md)
   * [Autocomplete entities](how-to-use-the-api/get-lists-of-entities/autocomplete-entities.md)
 * [Get content](how-to-use-the-api/get-content.md)
+* [Find similar works](how-to-use-the-api/find-similar-works.md)
 * [Get groups of entities](how-to-use-the-api/get-groups-of-entities.md)
 * [Rate limits and authentication](how-to-use-the-api/rate-limits-and-authentication.md)
 

--- a/docs/how-to-use-the-api/find-similar-works.md
+++ b/docs/how-to-use-the-api/find-similar-works.md
@@ -1,0 +1,177 @@
+---
+description: Find semantically similar works using vector search
+---
+
+# Find similar works
+
+OpenAlex's standard [search](get-lists-of-entities/search-entities.md) uses keyword matching—it finds works containing the words you type. But sometimes you want to find works that are *about* the same thing, even if they use different terminology.
+
+That's what `/find/works` does. It uses AI embeddings to find semantically similar works based on meaning, not just keywords. Search for "machine learning applications in drug discovery" and you'll find relevant papers even if they say "AI-driven pharmaceutical research" or "computational approaches to medicine."
+
+{% hint style="warning" %}
+Semantic search requires an API key and costs **1,000 credits per query**. See [rate limits](rate-limits-and-authentication.md) for details.
+{% endhint %}
+
+## How it works
+
+When you submit a query:
+
+1. We convert your text into a 1024-dimensional vector using an embedding model
+2. We search our index of ~217 million work embeddings for the most similar vectors
+3. We return the matching works, ranked by similarity score
+
+The embedding model ([GTE-Large](https://huggingface.co/thenlper/gte-large)) captures semantic meaning, so conceptually related works cluster together in vector space even when they use different words.
+
+## Basic usage
+
+### GET request
+
+```
+https://api.openalex.org/find/works?query=machine%20learning%20for%20drug%20discovery&api_key=YOUR_KEY
+```
+
+### POST request
+
+For longer queries (up to 10,000 characters), use POST:
+
+```bash
+curl -X POST "https://api.openalex.org/find/works?api_key=YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Your long query text here..."}'
+```
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `query` | The text to find similar works for (required, max 10,000 chars) | — |
+| `count` | Number of results to return (1-100) | 25 |
+| `filter` | Metadata filters (see below) | — |
+
+### Filters
+
+You can narrow results using these filters:
+
+| Filter | Example | Description |
+|--------|---------|-------------|
+| `publication_year` | `2023`, `>2020`, `2020-2023` | Filter by year |
+| `is_oa` | `true`, `false` | Open access only |
+| `has_abstract` | `true`, `false` | Has abstract |
+| `has_content.pdf` | `true`, `false` | Has downloadable PDF |
+| `has_content.grobid_xml` | `true`, `false` | Has parsed XML |
+
+**GET with filters:**
+
+```
+https://api.openalex.org/find/works?query=climate%20change%20adaptation&filter=publication_year:>2020,is_oa:true&count=50&api_key=YOUR_KEY
+```
+
+**POST with filters:**
+
+```bash
+curl -X POST "https://api.openalex.org/find/works?api_key=YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "climate change adaptation strategies",
+    "count": 50,
+    "filter": {
+      "publication_year": ">2020",
+      "is_oa": true
+    }
+  }'
+```
+
+## Response format
+
+```json
+{
+  "meta": {
+    "count": 25,
+    "query": "machine learning for drug discovery",
+    "filters_applied": {"publication_year": ">2020"},
+    "timing": {
+      "embed_ms": 145,
+      "search_ms": 89,
+      "hydrate_ms": 156,
+      "total_ms": 412
+    }
+  },
+  "results": [
+    {
+      "score": 0.8934,
+      "work": {
+        "id": "https://openalex.org/W4385012847",
+        "title": "Deep learning approaches for molecular property prediction",
+        "publication_year": 2023,
+        ...
+      }
+    },
+    ...
+  ]
+}
+```
+
+Each result includes:
+- `score`: Similarity score (0-1, higher is more similar)
+- `work`: The full [work object](../api-entities/works/work-object/), same as you'd get from `/works/{id}`
+
+## Example: Literature review assistant
+
+Say you're starting a literature review on CRISPR applications in agriculture. You could use keyword search, but you might miss papers that use terms like "genome editing," "gene modification," or "crop improvement" without mentioning "CRISPR" explicitly.
+
+**Step 1: Find semantically related works**
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.openalex.org/find/works",
+    params={
+        "query": "CRISPR gene editing applications in agriculture and crop improvement",
+        "filter": "publication_year:>2020,is_oa:true",
+        "count": 100,
+        "api_key": "YOUR_KEY"
+    }
+)
+
+results = response.json()["results"]
+print(f"Found {len(results)} related works")
+```
+
+**Step 2: Explore the results**
+
+```python
+for r in results[:10]:
+    print(f"{r['score']:.3f} | {r['work']['title'][:80]}")
+```
+
+You'll find works about plant genome modification, agricultural biotechnology, and crop science—even papers that never mention "CRISPR" directly but are highly relevant to your research.
+
+## Limitations
+
+{% hint style="info" %}
+**English-focused**: The embedding model is optimized for English text. Non-English works are indexed, but similarity matching will be less accurate.
+{% endhint %}
+
+{% hint style="info" %}
+**Abstracts required**: Only works with abstracts are indexed (~217 million works). Works without abstracts won't appear in results.
+{% endhint %}
+
+{% hint style="info" %}
+**No datasets**: Dataset entities are not currently included in the vector index.
+{% endhint %}
+
+## When to use semantic search vs keyword search
+
+| Use semantic search (`/find/works`) when... | Use keyword search (`/works?search=`) when... |
+|---------------------------------------------|-----------------------------------------------|
+| You want conceptually related works | You need exact term matches |
+| You're exploring a new research area | You know the specific terminology |
+| Your query is a sentence or paragraph | Your query is a few keywords |
+| You want to find works using different terminology | You want to filter by many metadata fields |
+
+## Credit costs
+
+| Action | Credits |
+|--------|---------|
+| Semantic search query | 1,000 |

--- a/docs/how-to-use-the-api/get-lists-of-entities/filter-entity-lists.md
+++ b/docs/how-to-use-the-api/get-lists-of-entities/filter-entity-lists.md
@@ -79,3 +79,7 @@ The filters for each entity can be found here:
 * [Concepts](../../api-entities/concepts/filter-concepts.md)
 * [Publishers](../../api-entities/publishers/filter-publishers.md)
 * [Funders](../../api-entities/funders/filter-funders.md)
+
+{% hint style="info" %}
+**Looking for text search?** Filters match exact attribute values. If you want to search for words in titles, abstracts, or other text fields, see [Search entities](search-entities.md). Or, for AI-powered semantic search that finds conceptually related works even when they use different terminology, check out [Find similar works](../find-similar-works.md).
+{% endhint %}

--- a/docs/how-to-use-the-api/get-lists-of-entities/search-entities.md
+++ b/docs/how-to-use-the-api/get-lists-of-entities/search-entities.md
@@ -59,3 +59,7 @@ You might be tempted to use the search filter to power an autocomplete or typeah
 
 👍 [`https://api.openalex.org/autocomplete/institutions?q=Florida`](https://api.openalex.org/autocomplete/institutions?q=Florida)
 {% endhint %}
+
+{% hint style="info" %}
+**Looking for semantic search?** The keyword search described on this page finds works containing specific words. If you want to find works that are *conceptually similar*—even when they use different terminology—check out [Find similar works](../find-similar-works.md), which uses AI embeddings to match by meaning.
+{% endhint %}


### PR DESCRIPTION
## Summary

Adds documentation for the new `/find/works` semantic search endpoint.

**New file:** `docs/how-to-use-the-api/find-similar-works.md`

### Content includes:
- Overview explaining semantic vs keyword search
- Endpoint details (GET/POST, parameters, filters)
- Response format with example JSON
- Practical example (literature review assistant)
- Limitations (English-focused, abstracts required, no datasets)
- Comparison table: when to use semantic vs keyword search
- Credit costs (1,000 per query)

### Related
- Part of job #24 in oax-jobs
- This PR should automatically create a GitBook change request for review

## Test plan
- [ ] Review documentation for accuracy
- [ ] Verify GitBook renders correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)