### PR TITLE
Treat quoted exact filter values as literals

### DIFF
--- a/core/fields.py
+++ b/core/fields.py
@@ -568,6 +568,18 @@ class TermField(Field):
         kwargs = {self.es_field(): formatted_values}
         return Q("terms", **kwargs)
 
+    def build_literal_query(self):
+        """
+        Build a pure literal term query for a fully quoted exact filter.
+
+        Skips the null / !null / leading-! syntax handled by build_query()
+        so that quoted values are matched verbatim, while still applying
+        the per-param value normalization in _get_formatted_value() (DOI
+        URL expansion, ORCID URL prefix, etc.).
+        """
+        value = self._get_formatted_value()
+        return Q("term", **{self.es_field(): value})
+
     def _get_formatted_value(self):
         """
         Get the formatted value for a single term, handling all the special cases.

--- a/core/filter.py
+++ b/core/filter.py
@@ -32,7 +32,14 @@ def filter_records(fields_dict, filter_params, s, sample=None):
             if is_quoted:
                 value = strip_outer_quotes_and_unescape(value)
                 field.value = value
-                s = s.filter(field.build_query())
+                # TermField has a literal path that skips its own null /
+                # !null / leading-! syntax; other field types fall back
+                # to their normal build_query() because they don't share
+                # that surface.
+                if isinstance(field, TermField):
+                    s = s.filter(field.build_literal_query())
+                else:
+                    s = s.filter(field.build_query())
                 continue
 
             # multiple OR queries have | in the param values

--- a/core/filter.py
+++ b/core/filter.py
@@ -4,7 +4,11 @@ from elasticsearch_dsl import Q
 
 from core.exceptions import APIQueryParamsError
 from core.fields import TermField
-from core.utils import get_field
+from core.utils import (
+    get_field,
+    is_wrapped_in_unescaped_quotes,
+    strip_outer_quotes_and_unescape,
+)
 from settings import MAX_IDS_IN_FILTER
 
 
@@ -15,15 +19,21 @@ def filter_records(fields_dict, filter_params, s, sample=None):
                 continue
             field = get_field(fields_dict, key)
 
-            # Quoted non-search values are single exact values (spaces are
-            # literal, not AND operators).  Strip the quotes and skip the
-            # space-split AND logic below.
+            # Quoted non-search values are single exact values: spaces are
+            # literal (not AND), `|` is literal (not OR), `*` is literal
+            # (not a wildcard), etc.  Strip the surrounding quotes,
+            # unescape `\"` -> `"` and `\\` -> `\`, then build the
+            # field's normal exact-match query directly, bypassing all
+            # operator parsing below.
             is_quoted = (
-                value.startswith('"') and value.endswith('"')
+                is_wrapped_in_unescaped_quotes(value)
                 and "search" not in field.param
             )
             if is_quoted:
-                value = value[1:-1]
+                value = strip_outer_quotes_and_unescape(value)
+                field.value = value
+                s = s.filter(field.build_query())
+                continue
 
             # multiple OR queries have | in the param values
             if "|" in value:
@@ -32,7 +42,6 @@ def filter_records(fields_dict, filter_params, s, sample=None):
             # multiple AND queries have + in the param values which is converted to a space
             elif (
                 " " in value
-                and not is_quoted
                 and "search" not in field.param
                 and type(field).__name__ != "RangeField"
                 and type(field).__name__ != "BooleanField"

--- a/core/utils.py
+++ b/core/utils.py
@@ -34,15 +34,38 @@ def split_filter_string(filter_string):
     Split a filter string by commas, but respect quoted strings.
     Commas inside double quotes are not treated as separators.
 
-    Example:
+    Inside a quoted region, `\\"` and `\\\\` are escape sequences and do
+    NOT close the quoted region.  Both characters of each escape sequence
+    are preserved verbatim here; consumers strip the surrounding quotes
+    and then unescape the value via ``strip_outer_quotes_and_unescape``.
+
+    Examples:
         'type:article,raw_affiliation_strings.search:"Dept of Chemistry, UCLA"'
         -> ['type:article', 'raw_affiliation_strings.search:"Dept of Chemistry, UCLA"']
+
+        'raw_affiliation_strings:"a \\"b, c\\" d",type:article'
+        -> ['raw_affiliation_strings:"a \\"b, c\\" d"', 'type:article']
     """
     parts = []
     current = ""
     in_quotes = False
+    i = 0
+    n = len(filter_string)
 
-    for char in filter_string:
+    while i < n:
+        char = filter_string[i]
+        # Inside a quoted region, `\"` and `\\` are escape sequences.
+        # Keep both characters as-is so the unescaper can resolve them
+        # later; the next `"` does not toggle the quote state.
+        if (
+            in_quotes
+            and char == "\\"
+            and i + 1 < n
+            and filter_string[i + 1] in ('"', "\\")
+        ):
+            current += filter_string[i : i + 2]
+            i += 2
+            continue
         if char == '"':
             in_quotes = not in_quotes
             current += char
@@ -52,11 +75,54 @@ def split_filter_string(filter_string):
             current = ""
         else:
             current += char
+        i += 1
 
     if current:
         parts.append(current)
 
     return parts
+
+
+def is_wrapped_in_unescaped_quotes(value):
+    """
+    Return True iff ``value`` is wrapped in `"..."` where the trailing
+    `"` is not backslash-escaped.  Used to identify fully quoted exact
+    filter values, e.g. ``"Some Library | City"`` or ``"a \\"b\\" c"``.
+    """
+    if len(value) < 2 or value[0] != '"' or value[-1] != '"':
+        return False
+    # Count consecutive backslashes immediately before the final `"`.
+    # If the count is even (including 0), the quote is unescaped.
+    backslashes = 0
+    j = len(value) - 2
+    while j >= 0 and value[j] == "\\":
+        backslashes += 1
+        j -= 1
+    return backslashes % 2 == 0
+
+
+def strip_outer_quotes_and_unescape(value):
+    """
+    Strip the surrounding `"` from a quoted exact value and unescape
+    ``\\"`` -> ``"`` and ``\\\\`` -> ``\\``.  Any other backslash is left
+    verbatim.
+
+    Callers should first verify the value is properly quoted via
+    :func:`is_wrapped_in_unescaped_quotes`.
+    """
+    inner = value[1:-1]
+    out = []
+    i = 0
+    n = len(inner)
+    while i < n:
+        ch = inner[i]
+        if ch == "\\" and i + 1 < n and inner[i + 1] in ('"', "\\"):
+            out.append(inner[i + 1])
+            i += 2
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
 
 
 def map_filter_params(filter_params):

--- a/tests/unit/test_param_mapping.py
+++ b/tests/unit/test_param_mapping.py
@@ -1,7 +1,13 @@
 import pytest
 
 from core.exceptions import APIQueryParamsError
-from core.utils import map_filter_params, map_sort_params
+from core.utils import (
+    is_wrapped_in_unescaped_quotes,
+    map_filter_params,
+    map_sort_params,
+    split_filter_string,
+    strip_outer_quotes_and_unescape,
+)
 
 
 class TestFilterParamMapping:
@@ -101,6 +107,59 @@ class TestFilterParamMapping:
         with pytest.raises(APIQueryParamsError) as exc_info:
             map_filter_params("publication_year:2020,doi:,cited_by_count:>10")
         assert "Invalid filter value for 'doi'" in str(exc_info.value)
+
+
+class TestQuoteHelpers:
+    """Direct coverage for the quote-aware helpers used by filter parsing."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ('"abc"', True),
+            ('"a \\"b\\" c"', True),   # escaped inner quotes, real outer
+            ('"a\\""', True),           # `\"` is inner escape, trailing `"` closes
+            ('"a\\"', False),           # final `"` is escaped -> unbalanced
+            ('"abc', False),            # unbalanced
+            ('abc"', False),            # unbalanced
+            ('""', True),               # empty quoted value
+            ('"\\\\"', True),           # quoted single backslash
+        ],
+    )
+    def test_is_wrapped_in_unescaped_quotes(self, value, expected):
+        assert is_wrapped_in_unescaped_quotes(value) is expected
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ('"abc"', "abc"),
+            ('"a \\"b\\" c"', 'a "b" c'),
+            ('"a\\\\b"', "a\\b"),       # `\\` -> `\`
+            ('"a\\nb"', "a\\nb"),      # other backslash escapes are left alone
+            ('""', ""),
+        ],
+    )
+    def test_strip_outer_quotes_and_unescape(self, value, expected):
+        assert strip_outer_quotes_and_unescape(value) == expected
+
+    def test_split_filter_string_keeps_escaped_quote_inside_quoted(self):
+        # `\"` inside the quoted region must not close the quote; the
+        # comma that follows is therefore part of the value.
+        parts = split_filter_string(
+            'raw_affiliation_strings:"a \\"b, c\\" d",type:article'
+        )
+        assert parts == [
+            'raw_affiliation_strings:"a \\"b, c\\" d"',
+            "type:article",
+        ]
+
+    def test_split_filter_string_plain_comma_in_quotes(self):
+        parts = split_filter_string(
+            'type:article,raw_affiliation_strings.search:"Dept, UCLA"'
+        )
+        assert parts == [
+            "type:article",
+            'raw_affiliation_strings.search:"Dept, UCLA"',
+        ]
 
 
 class TestSortParamMapping:

--- a/tests/unit/test_queries.py
+++ b/tests/unit/test_queries.py
@@ -191,6 +191,174 @@ def test_filter_or_query(client):
     }
 
 
+class TestQuotedExactFilter:
+    """Quoted non-search filter values are single literal exact terms:
+    operator characters inside the quotes (| * etc.) must NOT be parsed
+    as OpenAlex filter syntax."""
+
+    def test_quoted_value_with_pipe_is_single_term(self, client):
+        s = Search()
+        filter_args = 'raw_affiliation_strings:"Some Library | Some City"'
+        filter_params = map_filter_params(filter_args)
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "authorships.raw_affiliation_strings.keyword": "Some Library | Some City"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_quoted_value_with_wildcard_is_literal(self, client):
+        s = Search()
+        filter_args = 'raw_affiliation_strings:"Some * Library"'
+        filter_params = map_filter_params(filter_args)
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "authorships.raw_affiliation_strings.keyword": "Some * Library"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_unquoted_pipe_still_or_query(self, client):
+        s = Search()
+        filter_args = "raw_affiliation_strings:Some Library|Other Library"
+        filter_params = map_filter_params(filter_args)
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "terms": {
+                                "authorships.raw_affiliation_strings.keyword": [
+                                    "Some Library",
+                                    "Other Library",
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_quoted_value_on_search_field_uses_search_path(self, client):
+        """Search fields must keep their existing behavior: the quoted value
+        is passed to SearchOpenAlex and not routed through the literal
+        exact-term path on the .keyword subfield."""
+        s = Search()
+        filter_args = 'raw_affiliation_strings.search:"Some Library | Some City"'
+        filter_params = map_filter_params(filter_args)
+        s = filter_records(fields_dict, filter_params, s)
+        as_str = str(s.to_dict())
+        # Must not be routed to the exact .keyword term query.
+        assert "authorships.raw_affiliation_strings.keyword" not in as_str
+        # Must still hit the search analyzer path.
+        assert "authorships.raw_affiliation_strings" in as_str
+
+    def test_comma_inside_quoted_does_not_split_filters(self, client):
+        """Comma inside a quoted exact value must not be treated as a
+        filter separator, regardless of the new escape support."""
+        filter_params = map_filter_params(
+            'raw_affiliation_strings:"a,b",type:article'
+        )
+        assert filter_params == [
+            {"raw_affiliation_strings": '"a,b"'},
+            {"type": "article"},
+        ]
+        s = Search()
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "authorships.raw_affiliation_strings.keyword": "a,b"
+                            }
+                        },
+                        {"term": {"type.lower": "article"}},
+                    ]
+                }
+            }
+        }
+
+    def test_escaped_quotes_inside_quoted_value(self, client):
+        r"""`raw_affiliation_strings:"a \"b\" c"` -> exact literal `a "b" c`."""
+        filter_params = map_filter_params(
+            'raw_affiliation_strings:"a \\"b\\" c"'
+        )
+        # The parsed value keeps the escape sequence verbatim.
+        assert filter_params == [
+            {"raw_affiliation_strings": '"a \\"b\\" c"'}
+        ]
+        s = Search()
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "authorships.raw_affiliation_strings.keyword": 'a "b" c'
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_pipe_inside_quoted_with_escaped_quotes_is_literal(self, client):
+        r"""`raw_affiliation_strings:"a \"b|c\" d"` must not become an OR query."""
+        filter_params = map_filter_params(
+            'raw_affiliation_strings:"a \\"b|c\\" d"'
+        )
+        s = Search()
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "authorships.raw_affiliation_strings.keyword": 'a "b|c" d'
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_escaped_quotes_on_search_field_pass_through(self, client):
+        r"""Search fields keep existing behavior: the value is passed to
+        the search analyzer with quotes intact and is not routed through
+        the literal exact-term path on `.keyword`."""
+        filter_params = map_filter_params(
+            'raw_affiliation_strings.search:"a \\"b\\" c"'
+        )
+        s = Search()
+        s = filter_records(fields_dict, filter_params, s)
+        as_str = str(s.to_dict())
+        # Must not be routed to the exact .keyword term query.
+        assert "authorships.raw_affiliation_strings.keyword" not in as_str
+        # Must still hit the search analyzer path.
+        assert "authorships.raw_affiliation_strings" in as_str
+
+
 def test_sort_query(client):
     s = Search()
     filter_args = "host_venue.publisher:wiley,publication_year:>2015"

--- a/tests/unit/test_queries.py
+++ b/tests/unit/test_queries.py
@@ -358,6 +358,133 @@ class TestQuotedExactFilter:
         # Must still hit the search analyzer path.
         assert "authorships.raw_affiliation_strings" in as_str
 
+    # --- Quoted values must also bypass TermField's null / !null / leading-!
+    # syntax: inside quotes, those are data, not operators.
+
+    def test_quoted_null_is_literal_term(self, client):
+        s = Search()
+        filter_params = map_filter_params('raw_affiliation_strings:"null"')
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "authorships.raw_affiliation_strings.keyword": "null"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_quoted_bang_null_is_literal_term(self, client):
+        s = Search()
+        filter_params = map_filter_params('raw_affiliation_strings:"!null"')
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "authorships.raw_affiliation_strings.keyword": "!null"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_quoted_leading_bang_is_literal_term(self, client):
+        s = Search()
+        filter_params = map_filter_params(
+            'raw_affiliation_strings:"!literal"'
+        )
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "authorships.raw_affiliation_strings.keyword": "!literal"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_unquoted_null_still_missing_query(self, client):
+        s = Search()
+        filter_params = map_filter_params("raw_affiliation_strings:null")
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "bool": {
+                                "must_not": [
+                                    {
+                                        "exists": {
+                                            "field": "authorships.raw_affiliation_strings.keyword"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_unquoted_bang_null_still_exists_query(self, client):
+        s = Search()
+        filter_params = map_filter_params("raw_affiliation_strings:!null")
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "exists": {
+                                "field": "authorships.raw_affiliation_strings.keyword"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_unquoted_leading_bang_still_negated_term(self, client):
+        s = Search()
+        filter_params = map_filter_params(
+            "raw_affiliation_strings:!literal"
+        )
+        s = filter_records(fields_dict, filter_params, s)
+        assert s.to_dict() == {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "bool": {
+                                "must_not": [
+                                    {
+                                        "term": {
+                                            "authorships.raw_affiliation_strings.keyword": "literal"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
 
 def test_sort_query(client):
     s = Search()


### PR DESCRIPTION
Previously, exact filters like `raw_affiliation_strings:"A | B"` were mis-parsed as OR queries because the outer quotes were stripped before parser-level operators were applied, so `|` inside the quoted value was still interpreted as filter syntax.

This fixes that by treating fully quoted non-search filter values as a single literal value before parser-level operators are applied. It also:

- Teaches the comma-aware filter splitter about `\"` / `\\` escapes so embedded literal quotes can be written inside quoted exact values.
- Adds a literal query path for `TermField`, so quoted values like `"null"`, `"!null"`, and `"!literal"` match literally instead of triggering field-level null/negation syntax.

Unquoted filters and `.search` filters keep existing behavior.

### Verification

```bash
REDIS_DO_URL=redis://localhost:6379/0 REDISCLOUD_URL=redis://localhost:6379/1 \
USERS_DB_URL=postgresql://localhost/openalex \
env/bin/python -m pytest \
  tests/unit/test_param_mapping.py::TestQuoteHelpers \
  tests/unit/test_queries.py::TestQuotedExactFilter -q
```
