### PR TITLE
OQO spec core (#284): is_negated + group_by, bare values, NNF canonicalizer, generated schema

### DIFF
--- a/docs/oql-spec.md
+++ b/docs/oql-spec.md
@@ -398,16 +398,25 @@ Works where it's not Open Access
 
 ## 9. Valid Operators
 
-| Operator | OQL Syntax | Use Case |
-|----------|------------|----------|
-| `is` | `column is value` | Exact match (default) |
-| `is not` | `column is not value` | Negation |
-| `>=` | `column >= value` | Greater than or equal |
-| `<=` | `column <= value` | Less than or equal |
-| `>` | `column > value` | Greater than |
-| `<` | `column < value` | Less than |
-| `contains` | `column contains value` | Text search |
-| `does not contain` | `column does not contain value` | Negative text search |
+> **Updated by #284 (OQO spec):** leaf operators are now strictly **affirmative**.
+> The `is not` and `does not contain` operators were **removed** — negation is the
+> per-node `is_negated` polarity bit (one negation mechanism; canonical form is
+> NNF). OQL still *renders* "column is not value" / "column does not contain value"
+> for a negated leaf, but the underlying OQO encodes `operator: is`/`contains` +
+> `is_negated: true`. See **[`docs/oqo-spec.md`](./oqo-spec.md)** §4 and
+> `docs/oqo-schema.json`. Values are **bare** (no `entity/id` prefix) — see
+> oqo-spec.md §2. This OQL doc (v1.1) still shows the older prefixed/bracketed-ID
+> and operator forms below and is pending a parallel refresh.
+
+| Operator | OQL Syntax (rendered) | Underlying OQO |
+|----------|------------|------|
+| `is` | `column is value` | `operator: is` |
+| `>=` | `column >= value` | `operator: >=` |
+| `<=` | `column <= value` | `operator: <=` |
+| `>` | `column > value` | `operator: >` |
+| `<` | `column < value` | `operator: <` |
+| `contains` | `column contains value` | `operator: contains` |
+| *(negation)* | `column is not value` / `column does not contain value` | same operator + `is_negated: true` |
 
 ---
 

--- a/docs/oqo-schema.json
+++ b/docs/oqo-schema.json
@@ -1,390 +1,350 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openalex.org/schemas/oqo/v1.0",
+  "$id": "https://openalex.org/schemas/oqo/v1.1",
   "name": "OpenAlex_Query_Object",
-  "description": "The canonical JSON representation for OpenAlex queries. OQO serves as the intermediate format for bidirectional translation between URL parameters, OQL (human-readable query language), and programmatic JSON access.",
+  "description": "The canonical JSON representation for OpenAlex queries. OQO is the intermediate format for bidirectional translation between URL parameters, OQL (human-readable query language), and programmatic JSON access. GENERATED from query_translation/oqo.py by query_translation/regen_schema.py — do not hand-edit. Entity values are BARE (the namespace is the column_id, resolved via the column registry): 'I136199984', 'de', 'article', '13' — never 'institutions/I136199984'. Negation is the per-node 'is_negated' polarity bit; the canonical form is NNF (negation on leaves only). JSON is the normative serialization; YAML is display-only and MUST round-trip to identical JSON (quote every string value on emit).",
   "type": "object",
-  "required": ["get_rows"],
+  "required": [
+    "get_rows"
+  ],
   "additionalProperties": false,
   "properties": {
     "get_rows": {
       "$ref": "#/$defs/EntityType",
-      "description": "The entity type to retrieve. This determines what kind of records are returned (works, authors, institutions, etc.)."
+      "description": "The entity type to retrieve (works, authors, institutions, ...)."
     },
     "filter_rows": {
       "type": "array",
-      "description": "Filters applied to the rows being retrieved. Top-level array items are implicitly joined with AND.",
+      "description": "Filters applied to the retrieved rows. Top-level items are implicitly AND-joined.",
       "items": {
         "$ref": "#/$defs/Filter"
       },
       "default": []
     },
+    "group_by": {
+      "type": "array",
+      "description": "Group-by dimensions (Stage B). A LIST, so multi-dimensional grouping (e.g. topic x year) is expressible; dimension order is meaningful. Live serving impl is single-dimension only (multi-dim deferred to #297).",
+      "items": {
+        "$ref": "#/$defs/GroupBy"
+      },
+      "default": []
+    },
     "sort_by_column": {
-      "type": ["string", "null"],
-      "description": "The column/field to sort results by. Must be a valid sortable field for the entity type.",
-      "examples": ["cited_by_count", "publication_year", "fwci", "display_name", "works_count"]
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Column/field to sort results by. Must be a valid sortable field for the entity.",
+      "examples": [
+        "cited_by_count",
+        "publication_year",
+        "fwci",
+        "display_name",
+        "works_count"
+      ]
     },
     "sort_by_order": {
-      "type": ["string", "null"],
-      "enum": ["asc", "desc", null],
-      "description": "Sort direction. 'asc' for ascending, 'desc' for descending.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "asc",
+        "desc",
+        null
+      ],
+      "description": "Sort direction. 'asc' ascending, 'desc' descending.",
       "default": null
     },
     "sample": {
-      "type": ["integer", "null"],
+      "type": [
+        "integer",
+        "null"
+      ],
       "minimum": 1,
       "maximum": 10000,
-      "description": "Return a random sample of N results instead of all matching results. Useful for exploratory analysis.",
+      "description": "Return a random sample of N results instead of all matches.",
       "default": null
     }
   },
-
   "$defs": {
     "EntityType": {
       "type": "string",
-      "description": "Valid OpenAlex entity types. Native entities have OpenAlex-minted IDs (e.g., W123, A456). Non-native entities use external identifiers (e.g., country codes, type slugs).",
+      "description": "Valid OpenAlex entity types (the OQO `get_rows`). Sourced from oqo.VALID_ENTITY_TYPES.",
       "enum": [
-        "works",
         "authors",
-        "institutions",
-        "sources",
-        "publishers",
-        "funders",
-        "topics",
-        "keywords",
-        "concepts",
         "awards",
-        "countries",
+        "concepts",
         "continents",
+        "countries",
         "domains",
         "fields",
-        "subfields",
-        "sdgs",
+        "funders",
+        "institution-types",
+        "institutions",
+        "keywords",
         "languages",
         "licenses",
-        "types",
-        "source-types",
-        "institution-types",
         "locations",
-        "oa-statuses"
-      ],
-      "x-native-entities": {
-        "description": "Entities with OpenAlex-minted IDs (prefix + numeric ID)",
-        "entities": {
-          "works": { "prefix": "W", "example": "works/W2741809807" },
-          "authors": { "prefix": "A", "example": "authors/A5023888391" },
-          "institutions": { "prefix": "I", "example": "institutions/I136199984" },
-          "sources": { "prefix": "S", "example": "sources/S137773608" },
-          "publishers": { "prefix": "P", "example": "publishers/P4310319908" },
-          "funders": { "prefix": "F", "example": "funders/F4320332161" },
-          "topics": { "prefix": "T", "example": "topics/T10012" },
-          "concepts": { "prefix": "C", "example": "concepts/C86803240" },
-          "awards": { "prefix": "G", "example": "awards/G5453342221" }
-        }
-      },
-      "x-non-native-entities": {
-        "description": "Entities with external or well-known identifiers",
-        "entities": [
-          "countries",
-          "continents", 
-          "domains",
-          "fields",
-          "subfields",
-          "sdgs",
-          "languages",
-          "licenses",
-          "types",
-          "source-types",
-          "institution-types",
-          "keywords",
-          "locations",
-          "oa-statuses"
-        ],
-        "examples": {
-          "countries": "countries/de",
-          "sdgs": "sdgs/13",
-          "types": "types/article",
-          "languages": "languages/en",
-          "oa-statuses": "oa-statuses/gold"
-        }
-      }
-    },
-
-    "Filter": {
-      "description": "A filter can be either a leaf filter (single condition) or a branch filter (boolean combination of filters).",
-      "oneOf": [
-        { "$ref": "#/$defs/LeafFilter" },
-        { "$ref": "#/$defs/BranchFilter" }
+        "oa-statuses",
+        "publishers",
+        "sdgs",
+        "source-types",
+        "sources",
+        "subfields",
+        "topics",
+        "types",
+        "works"
       ]
     },
-
+    "Filter": {
+      "description": "A leaf filter (single condition) or a branch filter (boolean combination).",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LeafFilter"
+        },
+        {
+          "$ref": "#/$defs/BranchFilter"
+        }
+      ]
+    },
     "LeafFilter": {
       "type": "object",
-      "description": "A single filter condition. Specifies a column, value, and comparison operator.",
-      "required": ["column_id", "value"],
+      "description": "A single filter condition (a literal = atom + polarity).",
+      "required": [
+        "column_id",
+        "value"
+      ],
       "additionalProperties": false,
       "properties": {
         "column_id": {
           "type": "string",
-          "description": "The filter field/column identifier. Must be a valid filterable field for the entity type. Uses dot notation for nested fields.",
+          "description": "Filter field identifier; dot notation for nested fields. Valid columns/types come from the column registry, not this schema.",
           "examples": [
             "publication_year",
             "type",
             "open_access.is_oa",
             "authorships.institutions.lineage",
-            "authorships.author.id",
-            "primary_location.source.id",
-            "cited_by_count",
-            "fwci",
             "title_and_abstract.search",
             "sustainable_development_goals.id"
           ]
         },
         "value": {
-          "description": "The value to filter by. For entity IDs, use normalized format: entityName/id (e.g., 'institutions/I136199984', 'countries/de', 'sdgs/13'). For other values: integer for counts/years, boolean for flags, null for unknown/missing.",
+          "description": "BARE value (no entity prefix). Native IDs self-namespace via their letter prefix (A/W/I/S/F/T/...); non-native values are bare slugs/codes/ints disambiguated by column_id. String for ids/slugs/search, integer for counts/years, boolean for flags, null for missing.",
           "oneOf": [
-            { "type": "string" },
-            { "type": "integer" },
-            { "type": "number" },
-            { "type": "boolean" },
-            { "type": "null" }
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "examples": ["types/article", "institutions/I136199984", "countries/de", "sdgs/13", 2024, true, null]
+          "examples": [
+            "article",
+            "I136199984",
+            "de",
+            "13",
+            2024,
+            true,
+            null
+          ]
         },
         "operator": {
           "$ref": "#/$defs/Operator",
-          "description": "The comparison operator. Defaults to 'is' (exact match) if not specified.",
+          "description": "Comparison operator. Defaults to 'is'. Strictly affirmative — negation is `is_negated`, never an operator.",
           "default": "is"
+        },
+        "is_negated": {
+          "type": "boolean",
+          "description": "Polarity bit. true = the negation of this leaf (the single negation mechanism; maps 1:1 to URL `!`). In canonical (NNF) form, negation lives only on leaves.",
+          "default": false
         }
       }
     },
-
     "BranchFilter": {
       "type": "object",
-      "description": "A boolean combination of filters. Allows AND/OR grouping of multiple conditions.",
-      "required": ["join", "filters"],
+      "description": "A boolean combination of filters (AND/OR), optionally negated.",
+      "required": [
+        "join",
+        "filters"
+      ],
       "additionalProperties": false,
       "properties": {
         "join": {
           "type": "string",
-          "enum": ["and", "or"],
-          "description": "'and' requires all child filters to match. 'or' requires at least one child filter to match."
+          "enum": [
+            "and",
+            "or"
+          ],
+          "description": "'and' requires all children; 'or' requires at least one."
         },
         "filters": {
           "type": "array",
-          "description": "Array of child filters (can be leaf or branch filters, enabling nested boolean logic).",
+          "description": "Child filters (leaf or branch), enabling nested boolean logic.",
           "minItems": 1,
           "items": {
             "$ref": "#/$defs/Filter"
           }
+        },
+        "is_negated": {
+          "type": "boolean",
+          "description": "Negate the whole branch. The canonicalizer pushes this to the leaves via De Morgan (NNF), so a canonical OQO has is_negated only on leaves.",
+          "default": false
         }
       }
     },
-
+    "GroupBy": {
+      "type": "object",
+      "description": "A single group-by dimension.",
+      "required": [
+        "column_id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "column_id": {
+          "type": "string",
+          "description": "The column to group by.",
+          "examples": [
+            "primary_topic.id",
+            "publication_year",
+            "authorships.countries",
+            "sustainable_development_goals.id"
+          ]
+        }
+      }
+    },
     "Operator": {
       "type": "string",
-      "description": "Comparison operators for filter conditions.",
+      "description": "Leaf comparison operators (strictly affirmative). Sourced from oqo.VALID_OPERATORS. Negation is the `is_negated` bit, not an operator.",
       "enum": [
-        "is",
-        "is not",
-        ">",
-        ">=",
         "<",
         "<=",
+        ">",
+        ">=",
         "contains",
-        "does not contain"
+        "is"
       ],
-      "x-operator-categories": {
-        "equality": {
-          "operators": ["is", "is not"],
-          "description": "Exact match or negation. Default operator.",
-          "url_syntax": {
-            "is": "field:value",
-            "is not": "field:!value"
-          }
-        },
-        "comparison": {
-          "operators": [">", ">=", "<", "<="],
-          "description": "Numeric/date comparisons for range filters.",
-          "url_syntax": {
-            ">=": "field:value-",
-            "<=": "field:-value",
-            "range": "field:min-max"
-          }
-        },
-        "text": {
-          "operators": ["contains", "does not contain"],
-          "description": "Text search operators for search fields."
-        }
-      },
       "default": "is"
     }
   },
-
   "examples": [
     {
-      "description": "Simple type filter",
+      "description": "Type filter (bare value)",
       "value": {
         "get_rows": "works",
         "filter_rows": [
-          { "column_id": "type", "value": "types/article" }
+          {
+            "column_id": "type",
+            "value": "article"
+          }
         ]
       }
     },
     {
-      "description": "Multiple filters with AND (implicit at top level)",
+      "description": "AND of filters (implicit at top level), with range + boolean flag",
       "value": {
         "get_rows": "works",
         "filter_rows": [
-          { "column_id": "type", "value": "types/article" },
-          { "column_id": "publication_year", "value": 2024, "operator": ">=" },
-          { "column_id": "open_access.is_oa", "value": true }
+          {
+            "column_id": "type",
+            "value": "article"
+          },
+          {
+            "column_id": "publication_year",
+            "value": 2024,
+            "operator": ">="
+          },
+          {
+            "column_id": "open_access.is_oa",
+            "value": true
+          }
         ]
       }
     },
     {
-      "description": "OR within same field (type is article OR book)",
+      "description": "OR within a field (article OR review)",
       "value": {
         "get_rows": "works",
         "filter_rows": [
           {
             "join": "or",
             "filters": [
-              { "column_id": "type", "value": "types/article" },
-              { "column_id": "type", "value": "types/book" }
+              {
+                "column_id": "type",
+                "value": "article"
+              },
+              {
+                "column_id": "type",
+                "value": "review"
+              }
             ]
           }
         ]
       }
     },
     {
-      "description": "AND within same field (co-authorship: institution A AND institution B)",
+      "description": "Negation via is_negated (COVID NOT pediatric)",
       "value": {
         "get_rows": "works",
         "filter_rows": [
-          { "column_id": "authorships.institutions.lineage", "value": "institutions/I33213144" },
-          { "column_id": "authorships.institutions.lineage", "value": "institutions/I103163165" }
-        ]
-      }
-    },
-    {
-      "description": "Nested boolean: Harvard AND (Stanford OR MIT)",
-      "value": {
-        "get_rows": "works",
-        "filter_rows": [
-          { "column_id": "authorships.institutions.lineage", "value": "institutions/I136199984" },
           {
-            "join": "or",
-            "filters": [
-              { "column_id": "authorships.institutions.lineage", "value": "institutions/I97018004" },
-              { "column_id": "authorships.institutions.lineage", "value": "institutions/I63966007" }
-            ]
+            "column_id": "title_and_abstract.search",
+            "value": "covid",
+            "operator": "contains"
+          },
+          {
+            "column_id": "title_and_abstract.search",
+            "value": "pediatric",
+            "operator": "contains",
+            "is_negated": true
           }
         ]
       }
     },
     {
-      "description": "Negation (type is NOT article)",
+      "description": "Stage B: multi-dimensional group_by (topic x year)",
       "value": {
         "get_rows": "works",
         "filter_rows": [
-          { "column_id": "type", "value": "types/article", "operator": "is not" }
+          {
+            "column_id": "publication_year",
+            "value": 1976,
+            "operator": ">="
+          }
+        ],
+        "group_by": [
+          {
+            "column_id": "primary_topic.id"
+          },
+          {
+            "column_id": "publication_year"
+          }
         ]
       }
     },
     {
-      "description": "Range filter with sort",
+      "description": "Sort + sample (top-cited sample)",
       "value": {
         "get_rows": "works",
         "filter_rows": [
-          { "column_id": "publication_year", "value": 2020, "operator": ">=" },
-          { "column_id": "publication_year", "value": 2024, "operator": "<=" }
+          {
+            "column_id": "publication_year",
+            "value": 2024,
+            "operator": ">="
+          }
         ],
         "sort_by_column": "cited_by_count",
-        "sort_by_order": "desc"
-      }
-    },
-    {
-      "description": "Search filter",
-      "value": {
-        "get_rows": "works",
-        "filter_rows": [
-          { "column_id": "title_and_abstract.search", "value": "machine learning", "operator": "contains" }
-        ]
-      }
-    },
-    {
-      "description": "Null/unknown value filter",
-      "value": {
-        "get_rows": "works",
-        "filter_rows": [
-          { "column_id": "language", "value": null }
-        ]
-      }
-    },
-    {
-      "description": "Sample random results",
-      "value": {
-        "get_rows": "works",
-        "filter_rows": [
-          { "column_id": "publication_year", "value": 2024, "operator": ">=" }
-        ],
+        "sort_by_order": "desc",
         "sample": 100
-      }
-    },
-    {
-      "description": "Authors query with institution filter",
-      "value": {
-        "get_rows": "authors",
-        "filter_rows": [
-          { "column_id": "last_known_institutions.id", "value": "institutions/I136199984" }
-        ]
-      }
-    },
-    {
-      "description": "Institutions query with country filter",
-      "value": {
-        "get_rows": "institutions",
-        "filter_rows": [
-          { "column_id": "country_code", "value": "countries/us" }
-        ]
-      }
-    },
-    {
-      "description": "Complex OA compliance query",
-      "value": {
-        "get_rows": "works",
-        "filter_rows": [
-          { "column_id": "authorships.institutions.lineage", "value": "institutions/I241749" },
-          { "column_id": "open_access.oa_status", "value": "oa-statuses/gold" },
-          { "column_id": "type", "value": "types/article" }
-        ],
-        "sort_by_column": "fwci",
-        "sort_by_order": "desc"
-      }
-    },
-    {
-      "description": "SDG research query",
-      "value": {
-        "get_rows": "works",
-        "filter_rows": [
-          {
-            "join": "or",
-            "filters": [
-              { "column_id": "sustainable_development_goals.id", "value": "sdgs/13" },
-              { "column_id": "sustainable_development_goals.id", "value": "sdgs/7" }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "description": "Awards/funders query",
-      "value": {
-        "get_rows": "works",
-        "filter_rows": [
-          { "column_id": "awards.funder.id", "value": "funders/F4320332161" }
-        ]
       }
     }
   ]

--- a/docs/oqo-spec.md
+++ b/docs/oqo-spec.md
@@ -1,0 +1,261 @@
+# OQO (OpenAlex Query Object) Specification
+
+**Human-readable wrapper for `docs/oqo-schema.json`.** The schema is the
+machine-readable contract and is **generated** from the canonical dataclass
+(`query_translation/oqo.py`) by `query_translation/regen_schema.py` — never
+hand-edited. This document explains the model, the design decisions behind it,
+and the equality / canonicalization / rendering / serialization stances so future
+work doesn't relitigate them.
+
+Scope: **Stage A (filter / sort / sample) + Stage B (group_by)**. Stage C
+(filtering on groups / HAVING) and embedding-as-query are out of scope.
+
+> Provenance: this spec and schema are the deliverable of oxjob **#284**. The
+> worked-examples corpus that pressure-tested it (43 real queries spanning WoS /
+> Scopus / Dimensions / OXURL / OQO, each OXURL verified live) lives in that job.
+
+---
+
+## 1. The object
+
+An OQO is one JSON object:
+
+```jsonc
+{
+  "get_rows": "works",              // entity type to return (required)
+  "filter_rows": [ <Filter>, ... ], // implicitly AND-joined at the top level
+  "group_by":   [ <GroupBy>, ... ], // Stage B grouping dimensions (a list)
+  "sort_by_column": "cited_by_count",
+  "sort_by_order":  "desc",         // "asc" | "desc" | null
+  "sample": 100                     // random sample of N, or null
+}
+```
+
+A **`Filter`** is either a **`LeafFilter`** (one condition) or a **`BranchFilter`**
+(a boolean combination):
+
+```jsonc
+// LeafFilter — a single proposition (a "literal" = atom + polarity)
+{ "column_id": "publication_year", "value": 2020, "operator": ">=", "is_negated": false }
+
+// BranchFilter — AND/OR of child filters
+{ "join": "or", "filters": [ <Filter>, <Filter>, ... ], "is_negated": false }
+```
+
+A **`GroupBy`** is `{ "column_id": "primary_topic.id" }`.
+
+`get_rows` ∈ the entity enum (works, authors, institutions, sources, publishers,
+funders, topics, …). The full enum is in the schema (sourced from
+`VALID_ENTITY_TYPES`).
+
+---
+
+## 2. Values are **bare** (the column is the namespace)
+
+A filter `value` is a **bare scalar**. The namespace/type is carried by
+`column_id`, resolved via the **column registry** (§7) — it is *not* re-encoded as
+a prefix on the value.
+
+| Reference | OQO value | Not |
+|---|---|---|
+| Harvard | `"I136199984"` | ~~`"institutions/I136199984"`~~ |
+| Germany | `"de"` | ~~`"countries/de"`~~ |
+| article type | `"article"` | ~~`"types/article"`~~ |
+| SDG 13 | `"13"` | ~~`"sdgs/13"`~~ |
+| gold OA | `"gold"` | ~~`"oa-statuses/gold"`~~ |
+
+Why bare:
+
+- **DRY with the column registry.** The registry already owns "what type/namespace
+  does this column carry." A value prefix duplicates that → two sources that can
+  drift. The `column_id` always travels with the `value` in a LeafFilter, so the
+  namespace is always available without inlining it.
+- **Native IDs already self-namespace.** `A5023888391` is unambiguously an author
+  (the letter prefix `A`/`W`/`I`/`S`/`F`/`T`/… is part of the ID). `authors/…` is
+  pure redundancy.
+- **Renderers become near-identity.** Bare matches the OXURL filter values today
+  (`type:article`, `country_code:de`) and the planned OQL surface, so OQO→URL and
+  OQO→OQL stop being "strip the prefix" transforms.
+
+Non-native slugs (`de`, `article`, `13`, `en`) are only ambiguous in isolation;
+they are never in isolation — `column_id` disambiguates every one.
+
+Typed values: integers for counts/years, booleans for flags, `null` for
+unknown/missing. (See §6 on string-vs-typed in serialization.)
+
+---
+
+## 3. Boolean structure: one unified tree
+
+Boolean logic lives **only** in the tree shape, never inside a `value` string:
+
+- **AND / OR** are `BranchFilter.join`. Top-level `filter_rows` is an implicit AND.
+- A `LeafFilter` is a single proposition. Its `value` may carry **inline search
+  syntax** for the `contains` operator — `"phrase"` for an exact phrase, `*` / `?`
+  for wildcards, `"phrase"~N` for proximity — but **never** `AND`/`OR`/`NOT`; those
+  always lift to a `BranchFilter`.
+
+Example — `agile AND (supply chain OR value chain) AND (lead time OR cycle time)`:
+
+```jsonc
+{ "get_rows": "works", "filter_rows": [
+  { "column_id": "title_and_abstract.search", "value": "agile", "operator": "contains" },
+  { "join": "or", "filters": [
+      { "column_id": "title_and_abstract.search", "value": "supply chain", "operator": "contains" },
+      { "column_id": "title_and_abstract.search", "value": "value chain",  "operator": "contains" } ] },
+  { "join": "or", "filters": [
+      { "column_id": "title_and_abstract.search", "value": "lead time",  "operator": "contains" },
+      { "column_id": "title_and_abstract.search", "value": "cycle time", "operator": "contains" } ] }
+] }
+```
+
+The same tree can span **different search fields per block** (`display_name.search`,
+`title_and_abstract.search`, `default.search`) — `column_id` is per-leaf. (This is
+exactly the shape of large real systematic-review strategies.)
+
+---
+
+## 4. Negation: the `is_negated` polarity bit
+
+Negation is a boolean **`is_negated`** on every node (`LeafFilter` and
+`BranchFilter`). It is the **single** negation mechanism — the old `is not` /
+`does not contain` operators were removed. Leaf operators are strictly
+affirmative: `is`, `>`, `>=`, `<`, `<=`, `contains`.
+
+- A negated leaf maps 1:1 to the OpenAlex URL per-leaf negation `!`
+  (`field:!value`). It renders naturally as "foo is not bar".
+- `is_negated` on a branch negates the whole group.
+
+**Canonical form = NNF (negation normal form).** The canonicalizer pushes any
+branch-level `is_negated` down to the leaves via De Morgan (flip `and`↔`or`, toggle
+child polarity), cancels double negation, then flattens and sorts — so a
+*canonical* OQO carries `is_negated` only on leaves (a literal = atom + sign, the
+SAT/CNF/BDD standard). The representation permits `is_negated` anywhere; the
+canonical form restricts it to leaves.
+
+**Negation is safe / range-restricted**: it is closed-world set-complement *within
+the queried entity's result domain*, never absolute complement (relational-calculus
+safety / Datalog range-restriction / IR `AND NOT`). The URL `!` is already
+entity-scoped.
+
+Example — COVID papers excluding pediatric ones:
+
+```jsonc
+{ "get_rows": "works", "filter_rows": [
+  { "column_id": "title_and_abstract.search", "value": "covid",     "operator": "contains" },
+  { "column_id": "title_and_abstract.search", "value": "pediatric", "operator": "contains", "is_negated": true }
+] }
+```
+
+---
+
+## 5. Equality, canonicalization, and rendering (three separate layers)
+
+1. **Equality** — the semantic relation: `A OR B ≡ B OR A`; nested same-join groups
+   flatten; double negation cancels; De Morgan equivalents are equal. The spec
+   *defines* this relation; it is what "two OQOs mean the same query" means.
+2. **Canonicalizer** — an optional pure function `OQO → canonical OQO`
+   (`query_translation/oqo_canonicalizer.py`). It produces NNF, flattens same-join
+   groups, unwraps single-child groups, drops empties, coerces typed leaf values,
+   and **sorts** operands within every group + the top level (AND/OR are
+   commutative). Used **only** where a stable representation is needed: cache keys,
+   hashing, dedup, test fixtures. It **never** replaces the user's OQO. `group_by`
+   order is meaningful (dimension order) and is **preserved**, not sorted.
+3. **Rendering** — `OQO → URL / OQL` **preserves the user's operand order**. The
+   canonicalizer is invoked only when something needs a hash; rendering does not
+   canonicalize.
+
+> The canonicalizer sorts operands. Earlier impl did not; it now does (this doc and
+> the impl agree). Sorting is safe because it happens only in the canonical form,
+> which never feeds rendering.
+
+---
+
+## 6. Serialization: JSON normative, YAML display-only
+
+- **JSON is the normative serialization.** Hash / canonicalize over **JSON, never
+  YAML** — YAML emitter quoting/style choices change the bytes at identical
+  semantics, which would make hashes unstable.
+- **YAML is display/authoring only**, and a YAML rendering **MUST round-trip to
+  byte-identical JSON**. The safe direction is JSON→YAML; never treat hand-authored
+  YAML as authoritative without re-validating to JSON.
+- **Quote every string `value` on emit.** YAML's permissive scalar parsing means
+  user-controlled text means something different in YAML vs JSON:
+  - the country code `NO` coerces to boolean `false` (the "Norway problem") — and
+    still validates against the schema's `string|int|bool|null` union;
+  - a leading `*` wildcard (`*gene*`) breaks the YAML parse;
+  - a ` #` mid-value silently truncates the scalar (YAML comment);
+  - `year: 012` coerces to `10` (octal-ish) / loses the leading zero.
+  The fix is **serialization-layer** (quote-on-emit), not schema-layer — a JSON
+  Schema cannot catch coercion of a genuine `string|int|bool|null` union.
+- **Pin YAML 1.2 core schema** (smaller coercion surface than 1.1; kills
+  `yes/no/on/off` and sexagesimal).
+- **Per-column typing** (a `column_id → expected value type` map, owned by the
+  column registry) is useful defense-in-depth but only *detection-after-parse*: it
+  misses wrong-value-same-type coercion (`year: 012`→10) and `#`-truncation, so it
+  is **not** a substitute for quote-on-emit.
+
+(The canonicalizer's typed-value coercion in §5 operates on the in-memory dict /
+normative JSON, not on display YAML — different layers.)
+
+---
+
+## 7. Column validation lives in a registry, not the dataclass
+
+`LeafFilter.column_id` is intentionally a free `str` — the dataclass is
+**column-agnostic**. "Is this column valid on this entity? what value type? which
+operators?" is answered by a separate **column registry**, not by the OQO schema.
+
+- Current home of the registry: `openalex-gui/src/facetConfigs.js`.
+- A server-side copy (for validating OQO server-side) and the registry population
+  are tracked in oxjob **#294** (`column-registry-sync`). #284 ships the spec that
+  *names* the registry; #294 builds the thing it references.
+
+This is why §2 (bare values) works: the registry is the single type/namespace
+authority, so the value doesn't need to carry a prefix.
+
+---
+
+## 8. Stage B: `group_by` as a list
+
+`group_by` is a **list** of `GroupBy` dimensions, so multi-dimensional grouping
+(e.g. topic × year) is expressible in the spec:
+
+```jsonc
+{ "get_rows": "works",
+  "filter_rows": [ { "column_id": "publication_year", "value": 1976, "operator": ">=" } ],
+  "group_by":    [ { "column_id": "primary_topic.id" }, { "column_id": "publication_year" } ] }
+```
+
+Dimension order is meaningful and is preserved by the canonicalizer.
+
+**Live-impl gaps (spec is ahead of the server — deliberately):**
+
+- Multi-dimensional `group_by` (>1 dimension) is single-dimension only in the live
+  serving impl → **#297** (`group-by-extensions`).
+- Sorting groups by an aggregate metric (e.g. funders by mean citation impact) is
+  out of scope here (adjacent to Stage C) → **#297**. Groups sort by `_count` /
+  `_key`.
+
+---
+
+## 9. Documented `/works` default: `is_xpac:false`
+
+Every `/works` request to the walden index silently excludes `is_xpac:true` works
+unless the caller passes `&include_xpac=true` (`works/views.py`). The OQO spec
+**acknowledges this as part of `/works` semantics** — a documented default of the
+works domain, not a per-query flag. It does not push to flip the API default (a
+separate product decision). Consumers translating "all works" NL should be aware
+the default universe is narrowed.
+
+---
+
+## 10. Known impl lag (this round shipped the *spec core*)
+
+#284 shipped the spec-defining files: the `oqo.py` dataclass, the generated
+`oqo-schema.json`, the `oqo_canonicalizer.py` canonical form, and this prose. The
+translation impl in `query_translation/` (`oql_parser`, `oql_renderer`,
+`url_parser`, `url_renderer`, `validator`, and their tests) still references the
+removed operators and does not yet thread `is_negated` / `group_by`. That endpoint
+(`/query`) is not wired into the live OXURL serving path and is unreachable via the
+public proxy, so the lag is safe; updating it is the implementation follow-up.

--- a/query_translation/oqo.py
+++ b/query_translation/oqo.py
@@ -11,11 +11,22 @@ from typing import List, Optional, Union, Literal, Any, Dict
 
 @dataclass
 class LeafFilter:
-    """A single filter condition."""
+    """A single filter condition (a literal = atom + polarity).
+
+    `value` is a *bare* scalar — the namespace/type is carried by `column_id`
+    (resolved via the column registry), NOT by a prefix on the value. So an
+    institution reference is `"I136199984"`, a country is `"de"`, a type is
+    `"article"`, an SDG is `"13"` — never `"institutions/I136199984"` etc.
+
+    Negation is the `is_negated` polarity bit, never an operator: there is one
+    negation mechanism. (The old `is not` / `does not contain` operators are
+    removed; see VALID_OPERATORS.)
+    """
     column_id: str
     value: Union[str, int, bool, None]
     operator: str = "is"
-    
+    is_negated: bool = False
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "column_id": self.column_id,
@@ -23,29 +34,41 @@ class LeafFilter:
         }
         if self.operator != "is":
             result["operator"] = self.operator
+        if self.is_negated:
+            result["is_negated"] = True
         return result
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "LeafFilter":
         return cls(
             column_id=data["column_id"],
             value=data["value"],
-            operator=data.get("operator", "is")
+            operator=data.get("operator", "is"),
+            is_negated=data.get("is_negated", False),
         )
 
 
 @dataclass
 class BranchFilter:
-    """A boolean combination of filters."""
+    """A boolean combination of filters.
+
+    `is_negated` negates the whole branch (semantically a unary NOT node). The
+    canonicalizer pushes branch-level negation down to the leaves via De Morgan
+    (NNF), so a *canonical* OQO carries `is_negated` only on leaves.
+    """
     join: Literal["and", "or"]
     filters: List[Union["LeafFilter", "BranchFilter"]]
-    
+    is_negated: bool = False
+
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        result = {
             "join": self.join,
-            "filters": [f.to_dict() for f in self.filters]
+            "filters": [f.to_dict() for f in self.filters],
         }
-    
+        if self.is_negated:
+            result["is_negated"] = True
+        return result
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "BranchFilter":
         filters = []
@@ -54,7 +77,8 @@ class BranchFilter:
                 filters.append(BranchFilter.from_dict(f))
             else:
                 filters.append(LeafFilter.from_dict(f))
-        return cls(join=data["join"], filters=filters)
+        return cls(join=data["join"], filters=filters,
+                   is_negated=data.get("is_negated", False))
 
 
 FilterType = Union[LeafFilter, BranchFilter]
@@ -69,6 +93,24 @@ def filter_from_dict(data: Dict[str, Any]) -> FilterType:
 
 
 @dataclass
+class GroupBy:
+    """A single group-by dimension.
+
+    `group_by` on the OQO is a *list* of these, so multi-dimensional grouping
+    (e.g. topic × year) is expressible in the spec. The live serving impl is
+    single-dimension only; multi-dim impl is deferred to a follow-up job (#297).
+    """
+    column_id: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"column_id": self.column_id}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GroupBy":
+        return cls(column_id=data["column_id"])
+
+
+@dataclass
 class OQO:
     """OpenAlex Query Object - the canonical query representation."""
     get_rows: str
@@ -76,42 +118,50 @@ class OQO:
     sort_by_column: Optional[str] = None
     sort_by_order: Optional[Literal["asc", "desc"]] = None
     sample: Optional[int] = None
-    
+    group_by: List[GroupBy] = field(default_factory=list)
+
     def to_dict(self) -> Dict[str, Any]:
         result = {"get_rows": self.get_rows}
-        
+
         if self.filter_rows:
             result["filter_rows"] = [f.to_dict() for f in self.filter_rows]
-        
+
         if self.sort_by_column:
             result["sort_by_column"] = self.sort_by_column
-        
+
         if self.sort_by_order:
             result["sort_by_order"] = self.sort_by_order
-        
+
         if self.sample:
             result["sample"] = self.sample
-        
+
+        if self.group_by:
+            result["group_by"] = [g.to_dict() for g in self.group_by]
+
         return result
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "OQO":
         filter_rows = [filter_from_dict(f) for f in data.get("filter_rows", [])]
-        
+        group_by = [GroupBy.from_dict(g) for g in data.get("group_by", [])]
+
         return cls(
             get_rows=data["get_rows"],
             filter_rows=filter_rows,
             sort_by_column=data.get("sort_by_column"),
             sort_by_order=data.get("sort_by_order"),
-            sample=data.get("sample")
+            sample=data.get("sample"),
+            group_by=group_by,
         )
 
 
-# Valid operators
+# Valid leaf operators (strictly affirmative — negation is the `is_negated` bit,
+# not an operator). The old `is not` / `does not contain` were dropped in the
+# #284 spec: one negation mechanism only.
 VALID_OPERATORS = {
-    "is", "is not", 
+    "is",
     ">", ">=", "<", "<=",
-    "contains", "does not contain"
+    "contains",
 }
 
 # Valid entity types

--- a/query_translation/oqo_canonicalizer.py
+++ b/query_translation/oqo_canonicalizer.py
@@ -1,47 +1,93 @@
 """
-OQO Canonicalizer - Normalizes OQO for deterministic output.
+OQO Canonicalizer - Normalizes OQO into a deterministic canonical form.
 
-Canonicalization ensures:
-1. Typed values (int vs "int", bool vs "bool")
-2. Normalized entity IDs (lowercase, proper format)
-3. Flattened redundant AND groups
-4. Eliminated single-child groups
-5. Stable output for reliable tests
+The canonical form is used only where a *stable* representation is needed (cache
+keys, hashing, dedup, test fixtures). It NEVER replaces the user's OQO; rendering
+(OQO -> URL/OQL) preserves the user's operand order, and only invokes the
+canonicalizer when something needs a hash.
 
-See oql-oqo-plan.md Section 4 for canonicalization rules.
+Canonical form (per the #284 spec):
+1. Typed leaf values (string "true" -> bool, numeric strings -> int for numeric columns)
+2. **NNF (negation normal form)**: branch-level `is_negated` is pushed down to the
+   leaves via De Morgan (flip and<->or, toggle child polarity), double negation
+   cancels, so a canonical OQO carries `is_negated` only on leaves.
+3. Flattened nested same-join groups; single-child groups unwrapped; empty groups dropped.
+4. **Sorted** operands within every group and at the top level (AND/OR are commutative;
+   NOT lives only on leaves after NNF), giving order-independent output.
+
+Values are *bare* (the namespace is the column_id, resolved via the column
+registry) — there is no entity-id prefix normalization. See docs/oql-spec.md.
 """
 
+import json
 from typing import List, Union, Any
 from query_translation.oqo import OQO, LeafFilter, BranchFilter, FilterType
 
 
 def canonicalize_oqo(oqo: OQO) -> OQO:
     """
-    Canonicalize an OQO object for deterministic output.
-    
+    Canonicalize an OQO object into deterministic canonical form.
+
     Args:
         oqo: The OQO object to canonicalize
-    
+
     Returns:
         A new canonicalized OQO object
     """
     canonical_filters = []
     for f in oqo.filter_rows:
-        canonical_f = canonicalize_filter(f)
+        nnf_f = push_negation(f, negate=False)  # NNF first
+        canonical_f = canonicalize_filter(nnf_f)
         if canonical_f is not None:
             # Flatten if we get a single-child result that should be unwrapped
             if isinstance(canonical_f, list):
                 canonical_filters.extend(canonical_f)
             else:
                 canonical_filters.append(canonical_f)
-    
+
+    # Top-level filter_rows are an implicit AND -> commutative -> sort for stability
+    canonical_filters.sort(key=_sort_key)
+
     return OQO(
         get_rows=oqo.get_rows.lower(),  # Normalize entity type to lowercase
         filter_rows=canonical_filters,
         sort_by_column=oqo.sort_by_column,
         sort_by_order=oqo.sort_by_order,
-        sample=oqo.sample
+        sample=oqo.sample,
+        group_by=list(oqo.group_by),  # group_by order is meaningful (dim order) -> preserved
     )
+
+
+def push_negation(f: FilterType, negate: bool) -> FilterType:
+    """Push negation down to the leaves (De Morgan), producing NNF.
+
+    `negate` is the accumulated polarity from enclosing negated branches. A leaf
+    ends up with `is_negated = leaf.is_negated XOR negate`; a branch flips its
+    join (and<->or) and propagates the polarity when negated, then clears its own
+    `is_negated` (negation now lives on the leaves).
+    """
+    if isinstance(f, LeafFilter):
+        return LeafFilter(
+            column_id=f.column_id,
+            value=f.value,
+            operator=f.operator,
+            is_negated=bool(f.is_negated) ^ bool(negate),
+        )
+    if isinstance(f, BranchFilter):
+        eff = bool(f.is_negated) ^ bool(negate)
+        new_join = ("and" if f.join == "or" else "or") if eff else f.join
+        return BranchFilter(
+            join=new_join,
+            filters=[push_negation(c, eff) for c in f.filters],
+            is_negated=False,
+        )
+    return f
+
+
+def _sort_key(f: FilterType) -> str:
+    """Total order over filters for canonical operand sorting: the JSON of the
+    filter's dict with sorted keys. Stable and deterministic across runs."""
+    return json.dumps(f.to_dict(), sort_keys=True, ensure_ascii=True)
 
 
 def canonicalize_filter(f: FilterType) -> Union[FilterType, List[FilterType], None]:
@@ -63,31 +109,38 @@ def canonicalize_filter(f: FilterType) -> Union[FilterType, List[FilterType], No
 def canonicalize_leaf_filter(f: LeafFilter) -> LeafFilter:
     """
     Canonicalize a leaf filter.
-    
-    - Normalizes value types (string "true" -> bool True)
-    - Normalizes entity IDs
+
+    - Normalizes value types (string "true" -> bool True; numeric strings -> int)
+    - Preserves the `is_negated` polarity bit (already pushed to leaves by NNF)
+    - Values stay *bare* (no entity-id prefix normalization)
     """
     value = canonicalize_value(f.value, f.column_id)
     operator = f.operator or "is"
-    
+
     return LeafFilter(
         column_id=f.column_id,
         value=value,
-        operator=operator
+        operator=operator,
+        is_negated=bool(f.is_negated),
     )
 
 
 def canonicalize_value(value: Any, column_id: str) -> Any:
     """
     Canonicalize a filter value.
-    
+
     - Convert string booleans to actual booleans for boolean columns
     - Convert string integers to actual integers for numeric columns
-    - Normalize entity ID format
+
+    Values are *bare* — there is NO entity-id prefix normalization (the namespace
+    is the column_id, resolved via the column registry). This also means values
+    that legitimately contain "/" (e.g. a DOI like "10.1021/es052595+") pass
+    through untouched. Type coercion here is a stopgap keyed off a hardcoded
+    NUMERIC_COLUMNS set; the column registry (#294) is the eventual type authority.
     """
     if value is None:
         return None
-    
+
     # Boolean normalization
     if isinstance(value, str):
         lower_val = value.lower()
@@ -95,7 +148,7 @@ def canonicalize_value(value: Any, column_id: str) -> Any:
             return True
         if lower_val == "false":
             return False
-    
+
     # Integer normalization for known numeric columns
     if isinstance(value, str) and column_id in NUMERIC_COLUMNS:
         try:
@@ -106,55 +159,31 @@ def canonicalize_value(value: Any, column_id: str) -> Any:
                 return float(value)
         except ValueError:
             pass
-    
-    # Entity ID normalization
-    if isinstance(value, str) and "/" in value:
-        return normalize_entity_id(value)
-    
+
     return value
-
-
-def normalize_entity_id(entity_id: str) -> str:
-    """
-    Normalize an entity ID to canonical format.
-    
-    Examples:
-        - "Countries/CA" -> "countries/ca"
-        - "institutions/I123" -> "institutions/I123" (preserve case for OpenAlex IDs)
-        - "types/Article" -> "types/article"
-    """
-    if "/" not in entity_id:
-        return entity_id
-    
-    parts = entity_id.split("/", 1)
-    entity_type = parts[0].lower()
-    short_id = parts[1]
-    
-    # Preserve case for OpenAlex IDs (start with letter followed by numbers)
-    # Otherwise lowercase
-    if not (len(short_id) > 1 and short_id[0].isalpha() and short_id[1:].isdigit()):
-        short_id = short_id.lower()
-    
-    return f"{entity_type}/{short_id}"
 
 
 def canonicalize_branch_filter(f: BranchFilter) -> Union[FilterType, List[FilterType], None]:
     """
     Canonicalize a branch filter.
-    
+
     Rules:
     1. Recursively canonicalize children
     2. Remove empty children
-    3. Flatten single-child groups
-    4. Flatten nested same-join groups (AND inside AND)
+    3. Flatten nested same-join groups (AND inside AND)
+    4. Unwrap single-child groups
+    5. **Sort** children (AND/OR are commutative; NOT lives only on leaves after NNF)
+
+    Assumes the branch is already in NNF (branch-level negation pushed to leaves
+    by `push_negation`), so `is_negated` on a BranchFilter is not expected here.
     """
     canonical_children: List[FilterType] = []
-    
+
     for child in f.filters:
         canonical_child = canonicalize_filter(child)
         if canonical_child is None:
             continue
-        
+
         if isinstance(canonical_child, list):
             canonical_children.extend(canonical_child)
         elif isinstance(canonical_child, BranchFilter) and canonical_child.join == f.join:
@@ -162,18 +191,21 @@ def canonicalize_branch_filter(f: BranchFilter) -> Union[FilterType, List[Filter
             canonical_children.extend(canonical_child.filters)
         else:
             canonical_children.append(canonical_child)
-    
+
     # Empty group -> None
     if not canonical_children:
         return None
-    
+
     # Single child -> unwrap
     if len(canonical_children) == 1:
         return canonical_children[0]
-    
+
+    # Sort operands for order-independent canonical output
+    canonical_children.sort(key=_sort_key)
+
     return BranchFilter(
         join=f.join,
-        filters=canonical_children
+        filters=canonical_children,
     )
 
 

--- a/query_translation/regen_schema.py
+++ b/query_translation/regen_schema.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Regenerate docs/oqo-schema.json (JSON Schema) from the canonical OQO dataclass.
+
+The schema's *structure* mirrors `query_translation/oqo.py`; the dynamic parts —
+the entity-type enum and the operator enum — are pulled live from the module
+constants (`VALID_ENTITY_TYPES`, `VALID_OPERATORS`), so the schema can never drift
+from the dataclass's source of truth. Output is deterministic: re-running produces
+a byte-identical file (#284 ACCEPTANCE Test 1).
+
+Usage:
+    python -m query_translation.regen_schema           # writes docs/oqo-schema.json
+    python -m query_translation.regen_schema --check    # exit 1 if out of date
+"""
+import json
+import os
+import sys
+
+# import the dataclass module directly to avoid the package __init__ (web deps)
+import importlib.util
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.dirname(_HERE)
+SCHEMA_PATH = os.path.join(_REPO, "docs", "oqo-schema.json")
+
+
+def _load_oqo_module():
+    spec = importlib.util.spec_from_file_location("_oqo_src", os.path.join(_HERE, "oqo.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def build_schema() -> dict:
+    oqo = _load_oqo_module()
+    entity_types = sorted(oqo.VALID_ENTITY_TYPES)
+    operators = sorted(oqo.VALID_OPERATORS)  # {<, <=, >, >=, contains, is}
+
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://openalex.org/schemas/oqo/v1.1",
+        "name": "OpenAlex_Query_Object",
+        "description": (
+            "The canonical JSON representation for OpenAlex queries. OQO is the "
+            "intermediate format for bidirectional translation between URL "
+            "parameters, OQL (human-readable query language), and programmatic "
+            "JSON access. GENERATED from query_translation/oqo.py by "
+            "query_translation/regen_schema.py — do not hand-edit. Entity values "
+            "are BARE (the namespace is the column_id, resolved via the column "
+            "registry): 'I136199984', 'de', 'article', '13' — never "
+            "'institutions/I136199984'. Negation is the per-node 'is_negated' "
+            "polarity bit; the canonical form is NNF (negation on leaves only). "
+            "JSON is the normative serialization; YAML is display-only and MUST "
+            "round-trip to identical JSON (quote every string value on emit)."
+        ),
+        "type": "object",
+        "required": ["get_rows"],
+        "additionalProperties": False,
+        "properties": {
+            "get_rows": {
+                "$ref": "#/$defs/EntityType",
+                "description": "The entity type to retrieve (works, authors, institutions, ...).",
+            },
+            "filter_rows": {
+                "type": "array",
+                "description": "Filters applied to the retrieved rows. Top-level items are implicitly AND-joined.",
+                "items": {"$ref": "#/$defs/Filter"},
+                "default": [],
+            },
+            "group_by": {
+                "type": "array",
+                "description": (
+                    "Group-by dimensions (Stage B). A LIST, so multi-dimensional "
+                    "grouping (e.g. topic x year) is expressible; dimension order "
+                    "is meaningful. Live serving impl is single-dimension only "
+                    "(multi-dim deferred to #297)."
+                ),
+                "items": {"$ref": "#/$defs/GroupBy"},
+                "default": [],
+            },
+            "sort_by_column": {
+                "type": ["string", "null"],
+                "description": "Column/field to sort results by. Must be a valid sortable field for the entity.",
+                "examples": ["cited_by_count", "publication_year", "fwci", "display_name", "works_count"],
+            },
+            "sort_by_order": {
+                "type": ["string", "null"],
+                "enum": ["asc", "desc", None],
+                "description": "Sort direction. 'asc' ascending, 'desc' descending.",
+                "default": None,
+            },
+            "sample": {
+                "type": ["integer", "null"],
+                "minimum": 1,
+                "maximum": 10000,
+                "description": "Return a random sample of N results instead of all matches.",
+                "default": None,
+            },
+        },
+        "$defs": {
+            "EntityType": {
+                "type": "string",
+                "description": "Valid OpenAlex entity types (the OQO `get_rows`). Sourced from oqo.VALID_ENTITY_TYPES.",
+                "enum": entity_types,
+            },
+            "Filter": {
+                "description": "A leaf filter (single condition) or a branch filter (boolean combination).",
+                "oneOf": [
+                    {"$ref": "#/$defs/LeafFilter"},
+                    {"$ref": "#/$defs/BranchFilter"},
+                ],
+            },
+            "LeafFilter": {
+                "type": "object",
+                "description": "A single filter condition (a literal = atom + polarity).",
+                "required": ["column_id", "value"],
+                "additionalProperties": False,
+                "properties": {
+                    "column_id": {
+                        "type": "string",
+                        "description": "Filter field identifier; dot notation for nested fields. Valid columns/types come from the column registry, not this schema.",
+                        "examples": [
+                            "publication_year", "type", "open_access.is_oa",
+                            "authorships.institutions.lineage", "title_and_abstract.search",
+                            "sustainable_development_goals.id",
+                        ],
+                    },
+                    "value": {
+                        "description": "BARE value (no entity prefix). Native IDs self-namespace via their letter prefix (A/W/I/S/F/T/...); non-native values are bare slugs/codes/ints disambiguated by column_id. String for ids/slugs/search, integer for counts/years, boolean for flags, null for missing.",
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "integer"},
+                            {"type": "number"},
+                            {"type": "boolean"},
+                            {"type": "null"},
+                        ],
+                        "examples": ["article", "I136199984", "de", "13", 2024, True, None],
+                    },
+                    "operator": {
+                        "$ref": "#/$defs/Operator",
+                        "description": "Comparison operator. Defaults to 'is'. Strictly affirmative — negation is `is_negated`, never an operator.",
+                        "default": "is",
+                    },
+                    "is_negated": {
+                        "type": "boolean",
+                        "description": "Polarity bit. true = the negation of this leaf (the single negation mechanism; maps 1:1 to URL `!`). In canonical (NNF) form, negation lives only on leaves.",
+                        "default": False,
+                    },
+                },
+            },
+            "BranchFilter": {
+                "type": "object",
+                "description": "A boolean combination of filters (AND/OR), optionally negated.",
+                "required": ["join", "filters"],
+                "additionalProperties": False,
+                "properties": {
+                    "join": {
+                        "type": "string",
+                        "enum": ["and", "or"],
+                        "description": "'and' requires all children; 'or' requires at least one.",
+                    },
+                    "filters": {
+                        "type": "array",
+                        "description": "Child filters (leaf or branch), enabling nested boolean logic.",
+                        "minItems": 1,
+                        "items": {"$ref": "#/$defs/Filter"},
+                    },
+                    "is_negated": {
+                        "type": "boolean",
+                        "description": "Negate the whole branch. The canonicalizer pushes this to the leaves via De Morgan (NNF), so a canonical OQO has is_negated only on leaves.",
+                        "default": False,
+                    },
+                },
+            },
+            "GroupBy": {
+                "type": "object",
+                "description": "A single group-by dimension.",
+                "required": ["column_id"],
+                "additionalProperties": False,
+                "properties": {
+                    "column_id": {
+                        "type": "string",
+                        "description": "The column to group by.",
+                        "examples": ["primary_topic.id", "publication_year", "authorships.countries", "sustainable_development_goals.id"],
+                    },
+                },
+            },
+            "Operator": {
+                "type": "string",
+                "description": "Leaf comparison operators (strictly affirmative). Sourced from oqo.VALID_OPERATORS. Negation is the `is_negated` bit, not an operator.",
+                "enum": operators,
+                "default": "is",
+            },
+        },
+        "examples": [
+            {
+                "description": "Type filter (bare value)",
+                "value": {"get_rows": "works", "filter_rows": [{"column_id": "type", "value": "article"}]},
+            },
+            {
+                "description": "AND of filters (implicit at top level), with range + boolean flag",
+                "value": {"get_rows": "works", "filter_rows": [
+                    {"column_id": "type", "value": "article"},
+                    {"column_id": "publication_year", "value": 2024, "operator": ">="},
+                    {"column_id": "open_access.is_oa", "value": True},
+                ]},
+            },
+            {
+                "description": "OR within a field (article OR review)",
+                "value": {"get_rows": "works", "filter_rows": [
+                    {"join": "or", "filters": [
+                        {"column_id": "type", "value": "article"},
+                        {"column_id": "type", "value": "review"},
+                    ]},
+                ]},
+            },
+            {
+                "description": "Negation via is_negated (COVID NOT pediatric)",
+                "value": {"get_rows": "works", "filter_rows": [
+                    {"column_id": "title_and_abstract.search", "value": "covid", "operator": "contains"},
+                    {"column_id": "title_and_abstract.search", "value": "pediatric", "operator": "contains", "is_negated": True},
+                ]},
+            },
+            {
+                "description": "Stage B: multi-dimensional group_by (topic x year)",
+                "value": {"get_rows": "works",
+                          "filter_rows": [{"column_id": "publication_year", "value": 1976, "operator": ">="}],
+                          "group_by": [{"column_id": "primary_topic.id"}, {"column_id": "publication_year"}]},
+            },
+            {
+                "description": "Sort + sample (top-cited sample)",
+                "value": {"get_rows": "works",
+                          "filter_rows": [{"column_id": "publication_year", "value": 2024, "operator": ">="}],
+                          "sort_by_column": "cited_by_count", "sort_by_order": "desc", "sample": 100},
+            },
+        ],
+    }
+
+
+def render(schema: dict) -> str:
+    # deterministic: fixed insertion order + 2-space indent + trailing newline
+    return json.dumps(schema, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv):
+    text = render(build_schema())
+    if "--check" in argv:
+        current = open(SCHEMA_PATH, encoding="utf-8").read() if os.path.exists(SCHEMA_PATH) else ""
+        if current != text:
+            print("OUT OF DATE: docs/oqo-schema.json differs from generated. Run regen_schema.", file=sys.stderr)
+            return 1
+        print("docs/oqo-schema.json is up to date.")
+        return 0
+    with open(SCHEMA_PATH, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    print(f"Wrote {SCHEMA_PATH} ({len(text)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Ships the **spec-defining core** of the OpenAlex Query Object (OQO) from oxjob #284 — the worked-examples pressure-test (43 real queries across WoS/Scopus/Dimensions/OXURL/OQO, every OXURL verified live) drove these decisions.

## Why this is safe to merge
`query_translation/` (the `/query` endpoint) is **abandoned and disjoint** from the live OXURL serving path (`?filter=foo:bar`): neither imports the other, and `api.openalex.org/query` 404s via the proxy. So these changes don't touch live serving.

## What changed (the 4 files that *are* the spec)
- **`oqo.py`** — add `is_negated` polarity bit to `LeafFilter`/`BranchFilter`; add `GroupBy` + `group_by: list` to `OQO` (multi-dim grouping expressible); trim `VALID_OPERATORS` to strictly-affirmative `{is, >, >=, <, <=, contains}`. One negation mechanism only.
- **`oqo_canonicalizer.py`** — NNF push-down (De Morgan) + double-negation cancel; stable operand sort (order-independent canonical form); `group_by` passthrough; **drop entity-id prefix normalization** (values are now **bare** — also fixes a DOI slash-mangling bug `10.1021/es052595+`).
- **`regen_schema.py`** (new) — deterministic generator; `docs/oqo-schema.json` regenerated from the dataclass (entity/operator enums sourced live from the module). `--check` mode for CI.
- **`docs/oqo-spec.md`** (new) — human-readable OQO spec: bare values (the column is the namespace), unified boolean tree, `is_negated`/NNF/safe-negation, the equality/canonicalizer/rendering three-layer stance, JSON-normative serialization (quote-on-emit, YAML display-only), column registry (#294), `group_by`, the `is_xpac:false` `/works` default, and the impl-lag note.
- **`docs/oql-spec.md`** — flagged the operator/negation/value-format change; points to `oqo-spec.md`.

## Validation
- Schema regen is **idempotent** (`regen_schema.py --check` clean).
- All **42 in-scope worked-example OQOs validate** against the regenerated schema (#284 ACCEPTANCE Test 2).
- Canonicalizer verified: NNF on `NOT(A AND B)`, double-negation cancels, order-independent sort, `group_by` preserved, DOI passthrough, type coercion intact.

## Known lag (impl follow-up, not this PR)
The translation impl (`oql_parser`, `oql_renderer`, `url_parser`, `url_renderer`, `validator`) and their tests still encode the **old** prefixed values (`countries/ca`) + `is not`/`does not contain` operators, so those tests fail. Threading `is_negated`/`group_by`/bare-values through the renderers is the implementation follow-up. Documented in `oqo-spec.md` §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)